### PR TITLE
Citadel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ These are the things you will need in AWS prior to running the CFN Template
 * VPC (There should be a default, unless you want a new one)
 * SSH Security Group; just something that allows you port 22 via TCP from your IP. Must also be a part of the VPC chose previously
 * Subnet, any will do as long as it belongs to the VPC and is routed to an Internet Gateway eventually
-* Account with the following capabilities: [AWS::IAM::AccessKey, AWS::IAM::InstanceProfile, AWS::IAM::Policy, AWS::IAM::Role, AWS::IAM::User]
+* Account with the following capabilities: [AWS::IAM::InstanceProfile, AWS::IAM::Policy, AWS::IAM::Role]
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You will need to generate a slack token for hubot.
 2. Choose a bot username, this is what you will call to the bot in rooms as (e.g.; @hubot help)
 3. Find the API Token section (the token will start with `xoxb-`)
 
-## Pagerduty
+## Pagerduty Configuration
 You will need to acquire the following items (per the [hubot-pager-me](https://github.com/hubot-scripts/hubot-pager-me) project)
 
 * PAGERDUTY SUBDOMAIN - Your account subdomain (i.e.; $sudomain from $subdomain.pagerduty.com)
@@ -32,6 +32,7 @@ These are the things you will need in AWS prior to running the CFN Template
 * VPC (There should be a default, unless you want a new one)
 * SSH Security Group; just something that allows you port 22 via TCP from your IP. Must also be a part of the VPC chose previously
 * Subnet, any will do as long as it belongs to the VPC and is routed to an Internet Gateway eventually
+* Account with the following capabilities: [AWS::IAM::AccessKey, AWS::IAM::InstanceProfile, AWS::IAM::Policy, AWS::IAM::Role, AWS::IAM::User]
 
 # Usage
 
@@ -43,3 +44,17 @@ These are the things you will need in AWS prior to running the CFN Template
 * Choose whatever advanced options you choose (none are required); click next
 * Check the `I acknowledge that this template might cause AWS CloudFormation to create IAM resources.` portion
 * Click Create
+
+
+# Troubleshooting
+Always check the log locations first!
+
+* Bot Log Location: /var/log/bot/current
+* Redis Log Location (default): /var/log/redis/redis-server.log
+
+## Webhook Endpoint
+Endpoint Issues specifics to the Webhook/Http listener
+
+* Certificate Shows invalid
+    * Nginx may have not restarted after generating the real cert, restart nginx
+    * note: Service may show down, but `ps -ef | grep nginx` may return rouge processes that need to be killed

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These are the things you will need in AWS prior to running the CFN Template
 # Troubleshooting
 Always check the log locations first!
 
+* User Data Script Log: /var/log/user-data.log
 * Bot Log Location: /var/log/bot/current
 * Redis Log Location (default): /var/log/redis/redis-server.log
 

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -396,6 +396,7 @@
                 "curl -Sl ", { "Ref" : "UserDataScript" }," -o /user-init/userdata.sh\n",
                 "chmod +x /user-init/userdata.sh \n",
                 "export IAM_ROLE=", {"Ref" : "BotRole" } ," \n ",
+                "export REGION=", {"Ref" : "AWS::Region" } ," \n ",
                 "export BUCKET=", { "Ref" : "BotBucket" },"\n",
                 "export DOMAIN=", { "Ref" : "HostedZone" },"\n",
                 "export DAEMON=", { "Ref" : "Daemon" },"\n",

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -353,7 +353,7 @@
           "UserName" : {"Ref": "BotUser"}
         }
     },
-    "IncidentBotSecurityGroup" : {
+    "BotSecurityGroup" : {
       "Type" : "AWS::EC2::SecurityGroup",
       "Properties" : {
         "GroupDescription" : "Setup Ingress/Egress for Incident Bot",
@@ -365,24 +365,24 @@
            { "IpProtocol" : "tcp", "FromPort" : "80",  "ToPort" : "80",  "CidrIp" : "0.0.0.0/0"} ,
            { "IpProtocol" : "tcp", "FromPort" : "443", "ToPort" : "443", "CidrIp" : "0.0.0.0/0"} ],
         "Tags" : [
-           { "Key" : "Name", "Value" : "IncidentBot-Security-Group" }
+           { "Key" : "Name", "Value" : "Bot-Security-Group" }
         ]
       }
     },
     "ENI" : {
       "Type" : "AWS::EC2::NetworkInterface",
       "Properties" : {
-        "Tags": [ { "Key":"Name", "Value":"IncidentBot ENI" } ],
-        "Description": "Network Adapter for IncidentBot.",
+        "Tags": [ { "Key":"Name", "Value":"Bot ENI" } ],
+        "Description": "Network Adapter for Incident Bot.",
         "SourceDestCheck": "false",
         "GroupSet": [
-          { "Ref": "IncidentBotSecurityGroup" },
+          { "Ref": "BotSecurityGroup" },
           { "Ref": "SSHSecurityGroup" }
         ],
         "SubnetId": { "Ref": "Subnet" }
      }
     },
-    "IncidentBotInstance": {
+    "BotInstance": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "IamInstanceProfile": { "Ref": "BotInstanceProfile" },
@@ -392,7 +392,7 @@
         "ImageId" : { "Fn::FindInMap" : [ "AWSRegionArch2AMI", { "Ref" : "AWS::Region" },
                           { "Fn::FindInMap" : [ "AWSInstanceType2Arch", { "Ref" : "InstanceType" }, "Arch" ] } ] },
         "KeyName": { "Ref": "KeyName" },
-        "Tags": [ { "Key": "Name", "Value": "IncidentBot-Bot" } ],
+        "Tags": [ { "Key": "Name", "Value": "Bot-Bot" } ],
         "NetworkInterfaces" : [ {"NetworkInterfaceId" : {"Ref" : "ENI"}, "DeviceIndex" : 0 } ],
         "BlockDeviceMappings": [
           {
@@ -446,23 +446,23 @@
         }
       }
     },
-    "IncidentBotEIP": {
+    "BotEIP": {
       "Type": "AWS::EC2::EIP",
       "Properties": {
-        "InstanceId": { "Ref": "IncidentBotInstance" },
+        "InstanceId": { "Ref": "BotInstance" },
         "Domain": "vpc"
       }
     },
-    "IncidentBotDNS" : {
+    "BotDNS" : {
       "Type" : "AWS::Route53::RecordSet",
       "Properties" : {
         "HostedZoneName": { "Fn::Join" : [ "",[ { "Ref" : "HostedZone" } ,"." ] ] },
-        "Comment" : "DNS name for IncidentBot Bot",
+        "Comment" : "DNS name for Bot Bot",
         "Name" : { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" }, "." ] ] },
         "Type" : "A",
         "TTL" : "60",
         "ResourceRecords" : [
-           { "Ref": "IncidentBotEIP" }
+           { "Ref": "BotEIP" }
         ]
       }
     },
@@ -471,7 +471,7 @@
    },
    "WaitCondition" : {
      "Type" : "AWS::CloudFormation::WaitCondition",
-     "DependsOn" : "IncidentBotInstance",
+     "DependsOn" : "BotInstance",
      "Properties" : {
          "Handle" : { "Ref" : "BotWaitHandle" },
          "Timeout" : "900"
@@ -479,13 +479,13 @@
     }
   },
   "Outputs": {
-    "IncidentBotEIP": {
-      "Description": "EIP for IncidentBot Instance.",
-      "Value": { "Ref": "IncidentBotEIP" }
+    "BotEIP": {
+      "Description": "EIP for Incident Bot Instance.",
+      "Value": { "Ref": "BotEIP" }
     },
-    "IncidentBotEndpoint": {
+    "BotEndpoint": {
       "Description": "Endpoint for the incident bot Pagerduty Webhook.",
-      "Value": { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" }, "/hubot/pagerduty" ] ] }
+      "Value": { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" }, "/pagerduty" ] ] }
     }
   }
 }

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Cloudformation IncidentBot: Linux Bot; v1.1",
+  "Description": "Cloudformation Hubot Template: Incident Bot Configuration ; v1.2",
   "Parameters": {
     "KeyName": {
       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instance",

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Cloudformation Hubot Template: Incident Bot Configuration ; v1.2",
+  "Description": "Cloudformation Hubot Template: Incident Bot Configuration: v1.2",
   "Parameters": {
     "KeyName": {
       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instance",
@@ -392,8 +392,9 @@
                 "  exit 1\n",
                 "}\n",
                 "export -f error_exit\n",
-                "curl -Sl ", { "Ref" : "UserDataScript" }," -o /tmp/userdata.sh\n",
-                "chmod +x /user-init/userdata.sh \n",
+                "UDSCRIPT='/tmp/userdata.sh'\n",
+                "curl -Sl ", { "Ref" : "UserDataScript" }," -o ${UDSCRIPT}\n",
+                "chmod +x ${UDSCRIPT} \n",
                 "export IAM_ROLE=", {"Ref" : "BotRole" } ," \n ",
                 "export REGION=", {"Ref" : "AWS::Region" } ," \n ",
                 "export BUCKET=", { "Ref" : "BotBucket" },"\n",
@@ -413,8 +414,8 @@
                 "export COOKBOOK_BRANCH=", { "Ref" : "CookbookGitBranch" },"\n",
                 "export BOT_NAME=", { "Ref" : "BotName" },"\n",
                 "export HOSTNAME=", { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" } ] ] } ,"\n",
-                "/tmp/userdata.sh\n",
-                "rm -f /tmp/userata.sh\n",
+                "${UDSCRIPT}\n",
+                "rm -f ${UDSCRIPT}\n",
                 "# All is well so signal success and let CF know wait function is complete\n",
                 "/usr/local/bin/cfn-signal -e 0 -r \"Server setup complete\" '", { "Ref" : "BotWaitHandle" }, "'\n"
               ]

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -411,7 +411,7 @@
                 "export LE_EMAIL=", { "Ref" : "ContactEmail" },"\n",
                 "export COOKBOOK=", { "Ref" : "Cookbook" },"\n",
                 "export COOKBOOK_GIT=", { "Ref" : "CookbookGit" },"\n",
-                "export COOKBOOK_BRANCH=", { "Ref" : "CookbookBranch" },"\n",
+                "export COOKBOOK_BRANCH=", { "Ref" : "CookbookGitBranch" },"\n",
                 "export BOT_NAME=", { "Ref" : "BotName" },"\n",
                 "export HOSTNAME=", { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" } ] ] } ,"\n",
                 "/user-init/userdata.sh\n",

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -414,7 +414,7 @@
                 "export COOKBOOK_BRANCH=", { "Ref" : "CookbookGitBranch" },"\n",
                 "export BOT_NAME=", { "Ref" : "BotName" },"\n",
                 "export HOSTNAME=", { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" } ] ] } ,"\n",
-                "${UDSCRIPT}\n",
+                "${UDSCRIPT} || error_exit 'User Data Script failed'\n",
                 "rm -f ${UDSCRIPT}\n",
                 "# All is well so signal success and let CF know wait function is complete\n",
                 "/usr/local/bin/cfn-signal -e 0 -r \"Server setup complete\" '", { "Ref" : "BotWaitHandle" }, "'\n"

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -160,7 +160,7 @@
           },
           {
               "Label" : {"default": "Pagerduty Configuration"},
-              "Parameters" : ["ENVPagerDutyAPIKey", "ENVPagerDutyServiceKey", "ENVPagerDutySubDomain", "ENVPagerDutyUserID", "ENVPagerDutyRoom", "ENVPagerDutyServices"]
+              "Parameters" : ["ENVPagerDutySubDomain", "ENVPagerDutyUserID", "ENVPagerDutyAPIKey", "ENVPagerDutyServiceKey", "ENVPagerDutyRoom", "ENVPagerDutyServices"]
           },
           {
               "Label" : {"default": "Bot Configuration"},

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -269,14 +269,30 @@
       }
   },
   "Resources": {
-    "BotBucket" : {
-      "Type" : "AWS::S3::Bucket",
-      "DeletionPolicy" : "Retain",
-      "Properties" : {
-        "AccessControl" : "Private"
-      }
-    },
-    "IncidentBotUser" : {
+     "BotBucket" : {
+        "Type" : "AWS::S3::Bucket",
+        "DeletionPolicy" : "Retain",
+        "Properties" : {
+            "AccessControl" : "Private"
+        }
+     },
+     "BotRole": {
+        "Type": "AWS::IAM::Role",
+        "Properties": {
+           "AssumeRolePolicyDocument": {
+              "Version" : "2012-10-17",
+              "Statement": [ {
+                 "Effect": "Allow",
+                 "Principal": {
+                    "Service": [ "ec2.amazonaws.com" ]
+                 },
+                 "Action": [ "sts:AssumeRole" ]
+              } ]
+           },
+           "Path": "/"
+        }
+     },
+     "BotUser" : {
       "Type" : "AWS::IAM::User",
       "Properties" : {
         "Path": "/",
@@ -291,16 +307,51 @@
               "s3:PutObjectAcl",
               "s3:List*"
             ],
-            "Resource": { "Fn::Join" : [ "", [ "arn:aws:s3:::", { "Ref" : "BotBucket" }, "/*" ] ] }
+            "Resource":"*"
             }]}
           }]
         }
-      },
-      "HostKeys" : {
+     },
+     "RolePolicies": {
+        "Type": "AWS::IAM::Policy",
+        "Properties": {
+          "PolicyName": "bot-s3",
+          "PolicyDocument": {
+            "Version" : "2012-10-17",
+            "Statement":[ {
+            "Effect":"Allow",
+            "Action": [
+              "s3:GetObject",
+              "s3:Put",
+              "s3:PutObject",
+              "s3:PutObjectAcl",
+              "s3:List*"
+            ],
+            "Resource": { "Fn::Join" : [ "", [ "arn:aws:s3:::", { "Ref" : "BotBucket" }, "/*" ] ] }
+            } ]
+          },
+          "Roles": [ {
+             "Ref": "BotRole"
+          } ],
+          "Users": [ {
+             "Ref": "BotUser"
+          } ]
+      }
+     },
+     "BotInstanceProfile": {
+        "Type": "AWS::IAM::InstanceProfile",
+        "Properties": {
+           "Path": "/",
+           "Roles": [ {
+              "Ref": "BotRole"
+           } ]
+        }
+    },
+    "HostKeys" : {
         "Type" : "AWS::IAM::AccessKey",
         "Properties" : {
-          "UserName" : {"Ref": "IncidentBotUser"}
-      }
+          "UserName" : {"Ref": "BotUser"}
+        }
     },
     "IncidentBotSecurityGroup" : {
       "Type" : "AWS::EC2::SecurityGroup",
@@ -334,6 +385,7 @@
     "IncidentBotInstance": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
+        "IamInstanceProfile": { "Ref": "BotInstanceProfile" },
         "DisableApiTermination": "false",
         "InstanceInitiatedShutdownBehavior": "stop",
         "InstanceType": {"Ref": "InstanceType"},

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -304,21 +304,20 @@
           "PolicyName": "bot-s3",
           "PolicyDocument": {
             "Version" : "2012-10-17",
-            "Statement":[ {
-            "Effect":"Allow",
-            "Action": [
-              "s3:GetObject",
-              "s3:Put",
-              "s3:PutObject",
-              "s3:PutObjectAcl",
-              "s3:List*"
-            ],
-            "Resource": { "Fn::Join" : [ "", [ "arn:aws:s3:::", { "Ref" : "BotBucket" }, "/*" ] ] }
+            "Statement":[
+            {
+                "Effect":"Allow",
+                "Action": [ "s3:*" ],
+                "Resource": [ { "Fn::Join" : [ "", [ "arn:aws:s3:::", { "Ref" : "BotBucket" }, "/" ] ] },
+                              { "Fn::Join" : [ "", [ "arn:aws:s3:::", { "Ref" : "BotBucket" }, "/*" ] ] } ]
+            },
+            {
+                "Effect":"Allow",
+                "Action": [ "s3:ListAllMyBuckets" ],
+                "Resource": "arn:aws:s3:::*"
             } ]
           },
-          "Roles": [ {
-             "Ref": "BotRole"
-          } ]
+          "Roles": [ { "Ref": "BotRole" } ]
       }
      },
      "BotInstanceProfile": {

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -12,10 +12,10 @@
       "Default": "domain.com",
       "Description": "must match a route53 hosted domain/zone"
     },
-    "Subdomain": {
+    "BotName": {
       "Type": "String",
       "Default": "incidentbot",
-      "Description": "subdomain to attach to hosted zone"
+      "Description": "Sets both the Bot Name and Subdomain to attach to hosted zone"
     },
     "SSHSecurityGroup" : {
       "Description" : "Select Security Group for SSH Access",
@@ -26,6 +26,18 @@
       "Description" : "Choose VPC to use",
       "Type" : "AWS::EC2::VPC::Id",
       "Default": ""
+    },
+    "Daemon": {
+      "Description" : "Choose which daemon controller you wish to use",
+      "Type" : "String",
+      "Default": "runit",
+      "AllowedValues": ["runit", "supervisor"]
+    },
+    "Environment": {
+      "Description" : "Choose which environent you want to enable for Letsencrypt Certs",
+      "Type" : "String",
+      "Default": "production",
+      "AllowedValues": ["production", "stage"]
     },
     "ENVSlackToken": {
      "Description" : "Enter Slack HUBOT API Token",
@@ -74,6 +86,16 @@
       "Description" : "Enter URL for User Data script",
       "Type": "String",
       "Default": "https://raw.githubusercontent.com/HearstAT/cfn-incident-bot/master/userdata.sh"
+    },
+    "Cookbook": {
+      "Description" : "Enter Cookbook Name",
+      "Type": "String",
+      "Default": "incident_bot"
+    },
+    "CookbookGit": {
+      "Description" : "Enter HTTPS Git Clone URL for Cookbook",
+      "Type": "String",
+      "Default": "https://github.com/HearstAT/cookbook-incident-bot.git"
     },
     "Subnet": {
       "Description" : "Choose Subnet",
@@ -125,6 +147,58 @@
         "ConstraintDescription": "must be a valid EC2 instance type."
     }
    },
+  "Metadata" : {
+    "AWS::CloudFormation::Interface" : {
+      "ParameterGroups" : [
+          {
+              "Label" : {"default": "Instance & Network Configuration"},
+              "Parameters" : ["InstanceType", "KeyName", "VPC", "SSHSecurityGroup", "Subnet", "HostedZone"]
+          },
+          {
+              "Label" : {"default": "Slack Configuration"},
+              "Parameters" : ["ENVSlackToken"]
+          },
+          {
+              "Label" : {"default": "Pagerduty Configuration"},
+              "Parameters" : ["ENVPagerDutyAPIKey", "ENVPagerDutyServiceKey", "ENVPagerDutySubDomain", "ENVPagerDutyUserID", "ENVPagerDutyRoom", "ENVPagerDutyServices"]
+          },
+          {
+              "Label" : {"default": "Bot Configuration"},
+              "Parameters" : ["BotName", "Daemon"]
+          },
+          {
+              "Label" : {"default": "External Build Items"},
+              "Parameters" : ["Cookbook", "CookbookGit", "UserDataScript"]
+          },
+          {
+              "Label" : {"default": "Letsencrypt Configuration (SSL)"},
+              "Parameters" : ["Environment", "ContactEmail"]
+          }
+      ],
+      "ParameterLabels" : {
+        "InstanceType": {"default": "Pick a Server Size/Flavor:"},
+        "KeyName": {"default": "Pick a default Key Pair for Access:"},
+        "VPC": {"default": "Pick VPC to Build Instance In:"},
+        "SSHSecurityGroup": {"default": "Pick Security Group for SSH Access:"},
+        "Subnet": {"default": "Pick Subnet to Build Instance In:"},
+        "HostedZone": {"default": "Enter Route53 Domain:"},
+        "ENVSlackToken": {"default": "Enter Slack API Token:"},
+        "ENVPagerDutyAPIKey": {"default": "Enter Pager Duty API Key:"},
+        "ENVPagerDutyServiceKey": {"default": "Enter Service API Key:"},
+        "ENVPagerDutySubDomain": {"default": "Enter Pager Duty Subdomain:"},
+        "ENVPagerDutyUserID": {"default": "Enter Pager Duty User ID:"},
+        "ENVPagerDutyRoom": {"default": "Enter Slack Room for Pager Duty Alerts:"},
+        "ENVPagerDutyServices": {"default": "Enter Pager Duty Services (For Restriction):"},
+        "BotName": {"default": "Enter name for Bot:"},
+        "Daemon": {"default": "Pick Bot Service Daemon:"},
+        "Cookbook": {"default": "Enter Cookbook Name (If different):"},
+        "CookbookGit": {"default": "Enter Cookbook Git Clone URL (If different):"},
+        "UserDataScript": {"default": "Enter User Data Script URL (If different):"},
+        "Environment": {"default": "Pick Cert Type:"},
+        "ContactEmail": {"default": "Enter Email for Cert Notices:"}
+      }
+    }
+  },
    "Mappings" : {
      "AWSInstanceType2Arch" : {
        "t2.nano"     : { "Arch" : "HVM64"  },
@@ -195,6 +269,13 @@
       }
   },
   "Resources": {
+    "BotBucket" : {
+      "Type" : "AWS::S3::Bucket",
+      "DeletionPolicy" : "Retain",
+      "Properties" : {
+        "AccessControl" : "Private"
+      }
+    },
     "IncidentBotUser" : {
       "Type" : "AWS::IAM::User",
       "Properties" : {
@@ -210,7 +291,7 @@
               "s3:PutObjectAcl",
               "s3:List*"
             ],
-            "Resource":"*"
+            "Resource": { "Fn::Join" : [ "", [ "arn:aws:s3:::", { "Ref" : "BotBucket" }, "/*" ] ] }
             }]}
           }]
         }
@@ -219,13 +300,6 @@
         "Type" : "AWS::IAM::AccessKey",
         "Properties" : {
           "UserName" : {"Ref": "IncidentBotUser"}
-      }
-    },
-    "BotBucket" : {
-      "Type" : "AWS::S3::Bucket",
-      "DeletionPolicy" : "Retain",
-      "Properties" : {
-        "AccessControl" : "Private"
       }
     },
     "IncidentBotSecurityGroup" : {
@@ -293,11 +367,11 @@
                 "mkdir -p /user-init/ \n",
                 "curl -Sl ", { "Ref" : "UserDataScript" }," -o /user-init/userdata.sh\n",
                 "chmod +x /user-init/userdata.sh \n",
-                "export REGION=", {"Ref" : "AWS::Region" } ," \n ",
                 "export ACCESS_KEY=", {"Ref" : "HostKeys" } ," \n ",
                 "export SECRET_KEY=", {"Fn::GetAtt" : [ "HostKeys", "SecretAccessKey" ]} ," \n ",
                 "export BUCKET=", { "Ref" : "BotBucket" },"\n",
                 "export DOMAIN=", { "Ref" : "HostedZone" },"\n",
+                "export ENVIRONMENT=", { "Ref" : "Environment" },"\n",
                 "export SLACK_TOKEN=", { "Ref" : "ENVSlackToken" },"\n",
                 "export PAGERDUTY_API_KEY=", { "Ref" : "ENVPagerDutyAPIKey" },"\n",
                 "export PAGERDUTY_SERVICE_API_KEY=", { "Ref" : "ENVPagerDutyServiceKey" },"\n",
@@ -305,8 +379,10 @@
                 "export PAGERDUTY_USER_ID=", { "Ref" : "ENVPagerDutyUserID" },"\n",
                 "export PAGERDUTY_ROOM=", { "Ref" : "ENVPagerDutyRoom" },"\n",
                 "export PAGERDUTY_SERVICES=", { "Ref" : "ENVPagerDutyServices" },"\n",
-                "export EMAIL=", { "Ref" : "ContactEmail" },"\n",
-                "export HOSTNAME=", { "Fn::Join" : [ "", [ { "Ref" : "Subdomain" }, ".", { "Ref" : "HostedZone" } ] ] } ,"\n",
+                "export LE_EMAIL=", { "Ref" : "ContactEmail" },"\n",
+                "export COOKBOOK=", { "Ref" : "Cookbook" },"\n",
+                "export COOKBOOK_GIT=", { "Ref" : "CookbookGit" },"\n",
+                "export HOSTNAME=", { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" } ] ] } ,"\n",
                 "/user-init/userdata.sh\n",
                 "# All is well so signal success and let CF know wait function is complete\n",
                 "/usr/local/bin/cfn-signal -e 0 -r \"Server setup complete\" '", { "Ref" : "BotWaitHandle" }, "'\n"
@@ -328,7 +404,7 @@
       "Properties" : {
         "HostedZoneName": { "Fn::Join" : [ "",[ { "Ref" : "HostedZone" } ,"." ] ] },
         "Comment" : "DNS name for IncidentBot Bot",
-        "Name" : { "Fn::Join" : [ "", [ { "Ref" : "Subdomain" }, ".", { "Ref" : "HostedZone" }, "." ] ] },
+        "Name" : { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" }, "." ] ] },
         "Type" : "A",
         "TTL" : "60",
         "ResourceRecords" : [
@@ -350,8 +426,12 @@
   },
   "Outputs": {
     "IncidentBotEIP": {
-      "Description": "EIP for IncidentBot Instace.",
+      "Description": "EIP for IncidentBot Instance.",
       "Value": { "Ref": "IncidentBotEIP" }
+    },
+    "IncidentBotEndpoint": {
+      "Description": "Endpoint for the incident bot Pagerduty Webhook.",
+      "Value": { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" }, "/hubot/pagerduty" ] ] }
     }
   }
 }

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -313,7 +313,7 @@
             },
             {
                 "Effect":"Allow",
-                "Action": [ "s3:ListAllMyBuckets" ],
+                "Action": [ "s3:List*" ],
                 "Resource": "arn:aws:s3:::*"
             } ]
           },

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -371,6 +371,7 @@
                 "export SECRET_KEY=", {"Fn::GetAtt" : [ "HostKeys", "SecretAccessKey" ]} ," \n ",
                 "export BUCKET=", { "Ref" : "BotBucket" },"\n",
                 "export DOMAIN=", { "Ref" : "HostedZone" },"\n",
+                "export DAEMON=", { "Ref" : "Daemon" },"\n",
                 "export ENVIRONMENT=", { "Ref" : "Environment" },"\n",
                 "export SLACK_TOKEN=", { "Ref" : "ENVSlackToken" },"\n",
                 "export PAGERDUTY_API_KEY=", { "Ref" : "ENVPagerDutyAPIKey" },"\n",

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -34,7 +34,7 @@
       "AllowedValues": ["runit", "supervisor"]
     },
     "Environment": {
-      "Description" : "Choose which environent you want to enable for Letsencrypt Certs",
+      "Description" : "Choose which environment you want to enable for Letsencrypt Certs",
       "Type" : "String",
       "Default": "production",
       "AllowedValues": ["production", "stage"]
@@ -96,6 +96,11 @@
       "Description" : "Enter HTTPS Git Clone URL for Cookbook",
       "Type": "String",
       "Default": "https://github.com/HearstAT/cookbook-incident-bot.git"
+    },
+    "CookbookGitBranch": {
+      "Description" : "Enter Git Branch",
+      "Type": "String",
+      "Default": "master"
     },
     "Subnet": {
       "Description" : "Choose Subnet",
@@ -168,7 +173,7 @@
           },
           {
               "Label" : {"default": "External Build Items"},
-              "Parameters" : ["Cookbook", "CookbookGit", "UserDataScript"]
+              "Parameters" : ["Cookbook", "CookbookGit", "CookbookGitBranch", "UserDataScript"]
           },
           {
               "Label" : {"default": "Letsencrypt Configuration (SSL)"},
@@ -193,6 +198,7 @@
         "Daemon": {"default": "Pick Bot Service Daemon:"},
         "Cookbook": {"default": "Enter Cookbook Name (If different):"},
         "CookbookGit": {"default": "Enter Cookbook Git Clone URL (If different):"},
+        "CookbookBranch": {"default": "Enter Cookbook Git Branch to use (If different):"},
         "UserDataScript": {"default": "Enter User Data Script URL (If different):"},
         "Environment": {"default": "Pick Cert Type:"},
         "ContactEmail": {"default": "Enter Email for Cert Notices:"}
@@ -292,26 +298,6 @@
            "Path": "/"
         }
      },
-     "BotUser" : {
-      "Type" : "AWS::IAM::User",
-      "Properties" : {
-        "Path": "/",
-        "Policies": [{
-          "PolicyName": "incidentbot-get",
-          "PolicyDocument": { "Statement":[{
-            "Effect":"Allow",
-            "Action": [
-              "s3:GetObject",
-              "s3:Put",
-              "s3:PutObject",
-              "s3:PutObjectAcl",
-              "s3:List*"
-            ],
-            "Resource":"*"
-            }]}
-          }]
-        }
-     },
      "RolePolicies": {
         "Type": "AWS::IAM::Policy",
         "Properties": {
@@ -332,9 +318,6 @@
           },
           "Roles": [ {
              "Ref": "BotRole"
-          } ],
-          "Users": [ {
-             "Ref": "BotUser"
           } ]
       }
      },
@@ -345,12 +328,6 @@
            "Roles": [ {
               "Ref": "BotRole"
            } ]
-        }
-    },
-    "HostKeys" : {
-        "Type" : "AWS::IAM::AccessKey",
-        "Properties" : {
-          "UserName" : {"Ref": "BotUser"}
         }
     },
     "BotSecurityGroup" : {
@@ -419,8 +396,7 @@
                 "mkdir -p /user-init/ \n",
                 "curl -Sl ", { "Ref" : "UserDataScript" }," -o /user-init/userdata.sh\n",
                 "chmod +x /user-init/userdata.sh \n",
-                "export ACCESS_KEY=", {"Ref" : "HostKeys" } ," \n ",
-                "export SECRET_KEY=", {"Fn::GetAtt" : [ "HostKeys", "SecretAccessKey" ]} ," \n ",
+                "export IAM_ROLE=", {"Ref" : "BotRole" } ," \n ",
                 "export BUCKET=", { "Ref" : "BotBucket" },"\n",
                 "export DOMAIN=", { "Ref" : "HostedZone" },"\n",
                 "export DAEMON=", { "Ref" : "Daemon" },"\n",
@@ -435,6 +411,7 @@
                 "export LE_EMAIL=", { "Ref" : "ContactEmail" },"\n",
                 "export COOKBOOK=", { "Ref" : "Cookbook" },"\n",
                 "export COOKBOOK_GIT=", { "Ref" : "CookbookGit" },"\n",
+                "export COOKBOOK_BRANCH=", { "Ref" : "CookbookBranch" },"\n",
                 "export BOT_NAME=", { "Ref" : "BotName" },"\n",
                 "export HOSTNAME=", { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" } ] ] } ,"\n",
                 "/user-init/userdata.sh\n",
@@ -484,7 +461,7 @@
       "Value": { "Ref": "BotEIP" }
     },
     "BotEndpoint": {
-      "Description": "Endpoint for the incident bot Pagerduty Webhook.",
+      "Description": "Endpoint for the Incident Bot Pagerduty Webhook.",
       "Value": { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" }, "/pagerduty" ] ] }
     }
   }

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -435,6 +435,7 @@
                 "export LE_EMAIL=", { "Ref" : "ContactEmail" },"\n",
                 "export COOKBOOK=", { "Ref" : "Cookbook" },"\n",
                 "export COOKBOOK_GIT=", { "Ref" : "CookbookGit" },"\n",
+                "export BOT_NAME=", { "Ref" : "BotName" },"\n",
                 "export HOSTNAME=", { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" } ] ] } ,"\n",
                 "/user-init/userdata.sh\n",
                 "# All is well so signal success and let CF know wait function is complete\n",

--- a/incident-bot.json
+++ b/incident-bot.json
@@ -392,8 +392,7 @@
                 "  exit 1\n",
                 "}\n",
                 "export -f error_exit\n",
-                "mkdir -p /user-init/ \n",
-                "curl -Sl ", { "Ref" : "UserDataScript" }," -o /user-init/userdata.sh\n",
+                "curl -Sl ", { "Ref" : "UserDataScript" }," -o /tmp/userdata.sh\n",
                 "chmod +x /user-init/userdata.sh \n",
                 "export IAM_ROLE=", {"Ref" : "BotRole" } ," \n ",
                 "export REGION=", {"Ref" : "AWS::Region" } ," \n ",
@@ -414,7 +413,8 @@
                 "export COOKBOOK_BRANCH=", { "Ref" : "CookbookGitBranch" },"\n",
                 "export BOT_NAME=", { "Ref" : "BotName" },"\n",
                 "export HOSTNAME=", { "Fn::Join" : [ "", [ { "Ref" : "BotName" }, ".", { "Ref" : "HostedZone" } ] ] } ,"\n",
-                "/user-init/userdata.sh\n",
+                "/tmp/userdata.sh\n",
+                "rm -f /tmp/userata.sh\n",
                 "# All is well so signal success and let CF know wait function is complete\n",
                 "/usr/local/bin/cfn-signal -e 0 -r \"Server setup complete\" '", { "Ref" : "BotWaitHandle" }, "'\n"
               ]

--- a/userdata.sh
+++ b/userdata.sh
@@ -137,7 +137,7 @@ EOF
 
 cat > "${CHEFDIR}/Berksfile" <<EOF
 source 'https://supermarket.chef.io'
-cookbook "${COOKBOOK}", git: 'https://github.com/HearstAT/cookbook-incident-bot.git'
+cookbook "${COOKBOOK}", git: 'https://github.com/HearstAT/cookbook-incident-bot.git', branch: "citadel"
 EOF
 
 # Install dependencies

--- a/userdata.sh
+++ b/userdata.sh
@@ -62,6 +62,9 @@ easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-
 hostname ${HOSTNAME} || error_exit 'Failed to set hostname'
 echo ${HOSTNAME} > /etc/hostname || error_exit 'Failed to set hostname'
 
+mkdir -p /etc/chef/ohai/hints || error_exit 'Failed to create ohai folder'
+touch /etc/chef/ohai/hints/ec2.json || error_exit 'Failed to create ec2 hint file'
+touch /etc/chef/ohai/hints/iam.json || error_exit 'Failed to create iam hint file'
 
 # Add chef repo
 curl -s https://packagecloud.io/install/repositories/chef/stable/script.deb.sh | bash || error_exit 'Failed to add chef repo'
@@ -103,9 +106,7 @@ cat > "${CHEFDIR}/cfn.json" << EOF
 {
   "${COOKBOOK}": {
     "citadel": {
-        "bucket": "${BUCKET}",
-        "access_key_id": "${ACCESS_KEY}",
-        "secret_access_key": "${SECRET_KEY}"
+        "bucket": "${BUCKET}"
     },
     "aws": {
         "domain": "${DOMAIN}"

--- a/userdata.sh
+++ b/userdata.sh
@@ -58,7 +58,7 @@ fi
 # Mount S3 Bucket to Directory
 s3fs -o allow_other -o umask=000 -o iam_role=${IAM_ROLE} -o endpoint=${REGION} ${BUCKET} ${S3DIR} || error_exit 'Failed to mount s3fs'
 
-echo -e "${BUCKET} ${S3DIR} fuse.s3fs rw,_netdev,allow_other,umask=0022,iam_role=${IAM_ROLE},endpoint=${REGION},retries=5,multireq_max=5 0 0" >> /etc/fstab
+echo -e "${BUCKET} ${S3DIR} fuse.s3fs rw,_netdev,allow_other,umask=0022,iam_role=${IAM_ROLE},endpoint=${REGION},retries=5,multireq_max=5 0 0" >> /etc/fstab || error_exit 'Failed to add mount info to fstab'
 
 if [ ${ZERO_ENABLED} == 'false' ]; then
     echo 'nothing to see here'
@@ -78,7 +78,7 @@ touch /etc/chef/ohai/hints/iam.json || error_exit 'Failed to create iam hint fil
 
 # Add chef repo
 curl -s https://packagecloud.io/install/repositories/chef/stable/script.deb.sh | bash || error_exit 'Failed to add chef repo'
-apt-get update
+apt-get update || error_exit 'Failed to run apt-get update'
 
 # setup cookbooks directory
 if [ ! -d ${CHEFDIR} ]; then

--- a/userdata.sh
+++ b/userdata.sh
@@ -144,6 +144,8 @@ EOF
 sudo su -l -c "cd ${CHEFDIR} && export BERKSHELF_PATH=${CHEFDIR} && berks vendor" || error_exit 'Failed to run berks vendor'
 
 # Create client.rb
+mkdir -p /etc/chef
+
 cat > "/etc/chef/client.rb" <<EOF
 cookbook_path "${CHEFDIR}/berks-cookbooks"
 json_attribs "${CHEFDIR}/cfn.json"

--- a/userdata.sh
+++ b/userdata.sh
@@ -60,7 +60,8 @@ s3fs -o allow_other -o umask=000 -o iam_role=${IAM_ROLE} ${BUCKET} ${S3DIR} || e
 echo -e "${BUCKET} ${S3DIR} fuse.s3fs rw,_netdev,allow_other,umask=0022,iam_role=${IAM_ROLE},retries=5,multireq_max=5 0 0\n" >> /etc/fstab
 
 if [ ${ZERO_ENABLED} == 'false' ]; then
-# Placeholder for code to acquire validation pem
+    echo 'nothing to see here'
+    # Placeholder for code to acquire validation pem
 fi
 
 # Install cfn bootstraping tools

--- a/userdata.sh
+++ b/userdata.sh
@@ -3,6 +3,7 @@
 #### UserData Incident Bot Helper Script
 ### Script Params, exported in Cloudformation
 # ${IAM_ROLE} == BotRole
+# ${REGION} = Region
 # ${BUCKET} = BotBucket
 # ${DOMAIN} = HostedZone
 # ${DAEMON} = Daemon
@@ -55,9 +56,9 @@ if [ ! -d "${S3DIR}" ]; then
 fi
 
 # Mount S3 Bucket to Directory
-s3fs -o allow_other -o umask=000 -o iam_role=${IAM_ROLE} ${BUCKET} ${S3DIR} || error_exit 'Failed to mount s3fs'
+s3fs -o allow_other -o umask=000 -o iam_role=${IAM_ROLE} -o endpoint=${REGION} ${BUCKET} ${S3DIR} || error_exit 'Failed to mount s3fs'
 
-echo -e "${BUCKET} ${S3DIR} fuse.s3fs rw,_netdev,allow_other,umask=0022,iam_role=${IAM_ROLE},retries=5,multireq_max=5 0 0\n" >> /etc/fstab
+echo -e "${BUCKET} ${S3DIR} fuse.s3fs rw,_netdev,allow_other,umask=0022,iam_role=${IAM_ROLE},endpoint=${REGION},retries=5,multireq_max=5 0 0" >> /etc/fstab
 
 if [ ${ZERO_ENABLED} == 'false' ]; then
     echo 'nothing to see here'
@@ -156,6 +157,7 @@ EOF
 
 cat > "${CHEFDIR}/Berksfile" <<EOF
 source 'https://supermarket.chef.io'
+cookbook "citadel", git: 'https://github.com/gavinheavyside/citadel.git', branch: 'metadata-service'
 cookbook "${COOKBOOK}", git: '${COOKBOOK_GIT}', branch: '${COOKBOOK_BRANCH}'
 EOF
 

--- a/userdata.sh
+++ b/userdata.sh
@@ -2,13 +2,25 @@
 
 #### UserData Incident Bot Helper Script
 ### Script Params, exported in Cloudformation
-# ${REGION} == AWS::Region
 # ${ACCESS_KEY} == HostKeys
 # ${SECRET_KEY} == {"Fn::GetAtt" : [ "HostKeys", "SecretAccessKey" ]}
 # ${HOSTNAME} == Nodename or Server URL
+# ${BUCKET} = BotBucket
+# ${ENVIRONMENT} = Environment
+# ${SLACK_TOKEN} = ENVSlackToken
+# ${PAGERDUTY_API_KEY} = ENVPagerDutyAPIKey
+# ${PAGERDUTY_SERVICE_API_KEY} = ENVPagerDutyServiceKey
+# ${PAGERDUTY_SUBDOMAIN} = ENVPagerDutySubDomain
+# ${PAGERDUTY_USER_ID} = ENVPagerDutyUserID
+# ${PAGERDUTY_ROOM} = ENVPagerDutyRoom
+# ${PAGERDUTY_SERVICES} = ENVPagerDutyServices
+# ${LE_EMAIL} = ContactEmail
 ###
 
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+S3DIR='/opt/bot-s3'
+CHEFDIR='/var/chef/cookbooks'
 
 # Install S3FS Dependencies
 sudo apt-get install -y automake autotools-dev g++ git libcurl4-gnutls-dev libfuse-dev libssl-dev libxml2-dev make pkg-config
@@ -25,10 +37,10 @@ if [ ! -f "/usr/local/bin/s3fs" ]; then
   cd /tmp
   git clone https://github.com/s3fs-fuse/s3fs-fuse.git || error_exit 'Failed to clone s3fs-fuse'
   cd s3fs-fuse
-  ./autogen.sh
-  ./configure
-  make
-  sudo make install || error_exit 'Failed to make s3fs-fuse'
+  ./autogen.sh || error_exit 'Failed to run autogen for s3fs-fuse'
+  ./configure || error_exit 'Failed to run configure for s3fs-fuse'
+  make || error_exit 'Failed to make s3fs-fuse'
+  sudo make install || error_exit 'Failed run make-install s3fs-fuse'
 fi
 
 # Set S3FS Credentials
@@ -36,86 +48,85 @@ echo ${ACCESS_KEY}:${SECRET_KEY} > /etc/passwd-s3fs || error_exit 'Failed to set
 chmod 600 /etc/passwd-s3fs
 
 # Create S3FS Mount Directory
-if [ ! -d "/opt/redis" ]; then
-  mkdir /opt/redis
+if [ ! -d "${S3DIR}" ]; then
+  mkdir ${S3DIR}
 fi
-# Mount S3 Bucket to Directory
-s3fs -o allow_other -o umask=0002 -o passwd_file=/etc/passwd-s3fs ${BUCKET} /opt/redis || error_exit 'Failed to mount s3fs'
 
-# Add chef repo
-curl -s https://packagecloud.io/install/repositories/chef/stable/script.deb.sh | bash
+# Mount S3 Bucket to Directory
+s3fs -o allow_other -o umask=000 -o passwd_file=/etc/passwd-s3fs ${BUCKET} ${S3DIR} || error_exit 'Failed to mount s3fs'
 
 # Install cfn bootstraping tools
-easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-
-# Install awscli
-pip install awscli
+easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz || error_exit 'Failed to install CFN Bootstrap Tools'
 
 # Set hostname
 hostname ${HOSTNAME} || error_exit 'Failed to set hostname'
 echo ${HOSTNAME} > /etc/hostname || error_exit 'Failed to set hostname'
 
-# Run aws config
-aws configure set default.region ${REGION}
-aws configure set aws_access_key_id ${ACCESS_KEY}
-aws configure set aws_secret_access_key ${SECRET_KEY}
-
-CHEFDIR=/var/chef/cookbooks
-COOKBOOK='incident_bot'
 
 # Add chef repo
-curl -s https://packagecloud.io/install/repositories/chef/stable/script.deb.sh | bash
+curl -s https://packagecloud.io/install/repositories/chef/stable/script.deb.sh | bash || error_exit 'Failed to add chef repo'
 apt-get update
 
 # setup cookbooks directory
 if [ ! -d ${CHEFDIR} ]; then
   mkdir -p ${CHEFDIR}
 fi
-sudo chmod -R 777 /var/chef/cookbooks
 
-# Copy over the cookbooks
-CDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+sudo chmod -R 777 ${CHEFDIR}
 
 rm -f ${CHEFDIR}/${COOKBOOK}
 
 # Install Chef
 apt-get install -y chefdk || error_exit 'Failed to install chef'
 
-cat > "/var/chef/cookbooks/first-boot.json" << EOF
+
+# Setup Citadel Items
+mkdir -p ${S3DIR}/pagerduty ${S3DIR}/slack ${S3DIR}/aws ${S3DIR}/redis
+
+## Pagerduty
+echo "${PAGERDUTY_API_KEY}" >> ${S3DIR}/pagerduty/api_key
+echo "${PAGERDUTY_SERVICE_API_KEY}" >> ${S3DIR}/pagerduty/service_key
+echo "${PAGERDUTY_USER_ID}" >> ${S3DIR}/pagerduty/user_id
+echo "${PAGERDUTY_API_KEY}" >> ${S3DIR}/pagerduty/
+
+## Slack
+echo "${SLACK_TOKEN}" >> ${S3DIR}/slack/api_key
+
+if [ ${ENVIRONMENT} == 'production' ]; then
+    LE_ENDPOINT='https://acme-v01.api.letsencrypt.org'
+else
+    LE_ENDPOINT='https://acme-staging.api.letsencrypt.org'
+fi
+
+# Create json for CFN Params to Attributes
+cat > "${CHEFDIR}/cfn.json" << EOF
 {
   "${COOKBOOK}": {
-    "aws": {
-      "redis_bucket": "${BUCKET}",
-      "secret_key": "${SECRET_KEY}",
-      "access_key": "${ACCESS_KEY}",
-      "domain": "${DOMAIN}"
+    "citadel": {
+        "bucket": "${BUCKET}",
+        "access_key_id": "${ACCESS_KEY}",
+        "secret_access_key": "${SECRET_KEY}"
     },
-    "name": "devbot",
+    "aws": {
+        "domain": "${DOMAIN}"
+    },
+    "redis": {
+        "dir": "${S3DIR}/redis"
+    },
+    "name": "${BOT_NAME}",
     "adapter": "slack",
     "git_source": "https://github.com/github/hubot.git",
     "version": "2.18.0",
-    "user": "hubot",
-    "group": "hubot",
-    "daemon": "runit",
+    "daemon": "${DAEMON}",
     "config": {
-        "HUBOT_SLACK_TOKEN": "${SLACK_TOKEN}",
-        "HUBOT_PAGERDUTY_API_KEY": "${PAGERDUTY_API_KEY}",
-        "HUBOT_PAGERDUTY_SERVICE_API_KEY": "${PAGERDUTY_SERVICE_API_KEY}",
         "HUBOT_PAGERDUTY_SUBDOMAIN": "${PAGERDUTY_SUBDOMAIN}",
-        "HUBOT_PAGERDUTY_USER_ID": "${PAGERDUTY_USER_ID}",
         "HUBOT_PAGERDUTY_ROOM": "${PAGERDUTY_ROOM}",
         "HUBOT_PAGERDUTY_ENDPOINT": "/pagerduty",
         "HUBOT_PAGERDUTY_SERVICES": "${PAGERDUTY_SERVICES}"
     },
-    "external_scripts": [
-      "hubot-incident",
-      "hubot-pager-me",
-      "hubot-diagnostics",
-      "hubot-help",
-      "hubot-redis-brain"
-    ],
     "letsencrypt": {
-      "contact": "mailto:${EMAIL}"
+        "endpoint": "${LE_ENDPOINT}",
+        "contact": "mailto:${LE_EMAIL}"
     }
   },
   "run_list": [
@@ -132,10 +143,11 @@ EOF
 # Install dependencies
 sudo su -l -c "cd ${CHEFDIR} && export BERKSHELF_PATH=${CHEFDIR} && berks vendor" || error_exit 'Failed to run berks vendor'
 
-# create client.rb file so that Chef client can find its dependant cookbooks
-cat > "/var/chef/cookbooks/client.rb" <<EOF
+# Create client.rb
+cat > "/etc/chef/client.rb" <<EOF
 cookbook_path "${CHEFDIR}/berks-cookbooks"
+json_attribs "${CHEFDIR}/cfn.json"
 EOF
 
 # Run Chef
-sudo su -l -c 'chef-client -z -c "/var/chef/cookbooks/client.rb" -j "/var/chef/cookbooks/first-boot.json"' || error_exit 'Failed to run chef-client'
+sudo su -l -c 'chef-client -z -c "/etc/chef/client.rb"' || error_exit 'Failed to run chef-client'

--- a/userdata.sh
+++ b/userdata.sh
@@ -159,7 +159,7 @@ EOF
 
 cat > "${CHEFDIR}/Berksfile" <<EOF
 source 'https://supermarket.chef.io'
-cookbook "${COOKBOOK}", git: 'https://github.com/HearstAT/cookbook-incident-bot.git', branch: "citadel"
+cookbook "${COOKBOOK}", git: 'https://github.com/HearstAT/cookbook-incident-bot.git'
 EOF
 
 # Install dependencies

--- a/userdata.sh
+++ b/userdata.sh
@@ -113,7 +113,16 @@ else
     LE_ENDPOINT='https://acme-staging.api.letsencrypt.org'
 fi
 
-# Create json for CFN Params to Attributes
+
+if [ ${ZERO_ENABLED} == 'true' ]; then
+    RUN_TYPE='recipe'
+    RUN_ITEM=${COOKBOOK}
+else
+    RUN_TYPE='role'
+    RUN_ITEM=${ROLE}
+fi
+
+# Create json for CFN Params to Attributes and create local role file
 cat > "${CHEFDIR}/cfn.json" << EOF
 {
     "citadel": {
@@ -143,7 +152,7 @@ cat > "${CHEFDIR}/cfn.json" << EOF
         }
       },
     "run_list": [
-        "recipe[${COOKBOOK}]"
+        "${RUN_TYPE}[${RUN_ITEM}]"
     ]
 }
 EOF
@@ -177,7 +186,6 @@ validation_client_name "${CHEFGROUP}-validator"
 validation_key "${CHEFS3}/valdiation.pem"
 EOF
 fi
-
 
 # Run Chef
 sudo su -l -c 'chef-client' || error_exit 'Failed to run chef-client'


### PR DESCRIPTION
Merging Changes needed for Citadel.

Includes the following:
- No more IAM User, using a IAM Role and Profile instead to avoid Access/Secret keys being passed around
- IAM Rules are much scricter, only have full access to the folder created at run time, must have access to list all S3 items for mount with S3FS however
- Parameters are now ordered and in sections
  - Can now choose between Production/Stage Letsencrypt certs
  - Can now choose to clone a different branch of cookbook-incident-bot
- Bot Name and Sub-domain are now the same
- Secrets are now obscured and accessed via citadel
- userdata.sh now downloads to tmp file and is removed at completion
- Redis now directly creates dump.rdp in S3FS mount
- S3FS is now in FSTAB in-cast of reboots
- S3FS now mounts with cache, should limit S3 chatter
- Removed NGINX and L7_Redis cookbooks due to multiple issues
- Added Troubleshooting to README
